### PR TITLE
Fix designator initialization

### DIFF
--- a/src/sil_plugin.c
+++ b/src/sil_plugin.c
@@ -48,19 +48,19 @@ static const RzCmdDescHelp sil_command_help = {
 
 static sil_t *sil_plugin_create(RzCore *core) {
 	sil_opt_t opts = {
-		psk : rz_config_get(core->config, RZ_SIL_PSK),
-		address : rz_config_get(core->config, RZ_SIL_HOST),
-		port : rz_config_get(core->config, RZ_SIL_PORT),
-		timeout : rz_config_get_i(core->config, RZ_SIL_TIMEOUT),
+		.psk = rz_config_get(core->config, RZ_SIL_PSK),
+		.address = rz_config_get(core->config, RZ_SIL_HOST),
+		.port = rz_config_get(core->config, RZ_SIL_PORT),
+		.timeout = rz_config_get_i(core->config, RZ_SIL_TIMEOUT),
 #if HAVE_LIB_SSL
-		use_tls : rz_config_get_b(core->config, RZ_SIL_TLS),
+		.use_tls = rz_config_get_b(core->config, RZ_SIL_TLS),
 #else
-		use_tls : false,
+		.use_tls = false,
 #endif
-		show_msg : rz_config_get_b(core->config, RZ_SIL_SRV_TEXT),
-		can_share : rz_config_get_b(core->config, RZ_SIL_SHARE),
-		can_share_sections : rz_config_get_b(core->config, RZ_SIL_SHARE_SECTIONS),
-		can_share_symbols : rz_config_get_b(core->config, RZ_SIL_SHARE_SYMBOLS),
+		.show_msg = rz_config_get_b(core->config, RZ_SIL_SRV_TEXT),
+		.can_share = rz_config_get_b(core->config, RZ_SIL_SHARE),
+		.can_share_sections = rz_config_get_b(core->config, RZ_SIL_SHARE_SECTIONS),
+		.can_share_symbols = rz_config_get_b(core->config, RZ_SIL_SHARE_SYMBOLS),
 	};
 	return sil_new(&opts);
 }


### PR DESCRIPTION
Fixes following warnings:
```
../src/sil_plugin.c:51:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                psk : rz_config_get(core->config, RZ_SIL_PSK),
                ^~~~~
                .psk =
../src/sil_plugin.c:52:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                address : rz_config_get(core->config, RZ_SIL_HOST),
                ^~~~~~~~~
                .address =
../src/sil_plugin.c:53:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                port : rz_config_get(core->config, RZ_SIL_PORT),
                ^~~~~~
                .port =
../src/sil_plugin.c:54:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                timeout : rz_config_get_i(core->config, RZ_SIL_TIMEOUT),
                ^~~~~~~~~
                .timeout =
../src/sil_plugin.c:58:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                use_tls : false,
                ^~~~~~~~~
                .use_tls =
../src/sil_plugin.c:60:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                show_msg : rz_config_get_b(core->config, RZ_SIL_SRV_TEXT),
                ^~~~~~~~~~
                .show_msg =
../src/sil_plugin.c:61:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                can_share : rz_config_get_b(core->config, RZ_SIL_SHARE),
                ^~~~~~~~~~~
                .can_share =
../src/sil_plugin.c:62:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                can_share_sections : rz_config_get_b(core->config, RZ_SIL_SHARE_SECTIONS),
                ^~~~~~~~~~~~~~~~~~~~
                .can_share_sections =
../src/sil_plugin.c:63:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
                can_share_symbols : rz_config_get_b(core->config, RZ_SIL_SHARE_SYMBOLS),
                ^~~~~~~~~~~~~~~~~~~
                .can_share_symbols =
```