### PR TITLE
Use RzPVector for sections

### DIFF
--- a/src/sil_client.c
+++ b/src/sil_client.c
@@ -464,10 +464,9 @@ static SectionHash *sil_section_digest(RzCore *core, RzBinSection *bsect, const 
 static bool sil_request_and_apply_hints(sil_t *sil, RzCore *core, sil_stats_t *stats) {
 	bool result = true;
 	const RzHashPlugin *blake = NULL;
-	const RzList *list = NULL;
+	const RzPVector *sections = NULL;
 	RzBinObject *bo = NULL;
 	RzBinSection *bsect = NULL;
-	RzListIter *it = NULL;
 	Binary *binary = NULL;
 
 	blake = rz_hash_plugin_by_name(core->hash, "blake3");
@@ -482,14 +481,16 @@ static bool sil_request_and_apply_hints(sil_t *sil, RzCore *core, sil_stats_t *s
 		return false;
 	}
 
-	list = rz_bin_object_get_sections_all(bo);
+	sections = rz_bin_object_get_sections_all(bo);
 
 	const char *type = bo->plugin ? bo->plugin->name : NULL;
 	const char *os = bo->info ? bo->info->os : NULL;
 
-	binary = proto_binary_new(type, os, rz_list_length(list));
+	binary = proto_binary_new(type, os, rz_pvector_len(sections));
 
-	rz_list_foreach (list, it, bsect) {
+	void **it;
+	rz_pvector_foreach (sections, it) {
+		bsect = (RzBinSection *)*it;
 		if (!(bsect->perm & RZ_PERM_X)) {
 			continue;
 		}


### PR DESCRIPTION
Fix this problem:
```
../src/sil_client.c:485:7: warning: incompatible pointer types assigning to 'const RzList *' (aka 'const struct rz_list_t *') from 'const RzPVector *' (aka 'const struct rz_pvector_t *') [-Wincompatible-pointer-types]
        list = rz_bin_object_get_sections_all(bo);
             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
It should be used in 0.7.0/0.7.1 releases as well (or Cutter 2.3.4) because the API change happened before 0.7.0